### PR TITLE
deploy: add Procfile for app platform

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8080}

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ make dev
 ```
 
 Visit http://localhost:8000 to browse.
+
+## Deployment
+
+App platforms like DigitalOcean require an explicit start command. A `Procfile` is included to run the app:
+
+```
+web: uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8080}
+```


### PR DESCRIPTION
## Summary
- add Procfile with explicit uvicorn start command for platforms like DigitalOcean
- document start command in README

## Testing
- `ruff check . && black --check . && pytest -q` *(fails: async def functions are not natively supported)*
- `pip install pytest-asyncio` *(fails: Cannot connect to proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c61a7c6878832c8031853d3d459468