### PR TITLE
docs: clarify DigitalOcean build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ Visit http://localhost:8000 to browse.
 
 ## Deployment
 
-App platforms like DigitalOcean require an explicit start command. A `Procfile` is included to run the app:
+App platforms like DigitalOcean expect both a build step and a start command.
+During the build step install dependencies, for example:
+
+```
+pip install -r requirements.txt
+```
+
+A `Procfile` is included to run the app during the start phase:
 
 ```
 web: uvicorn backend.main:app --host 0.0.0.0 --port ${PORT:-8080}


### PR DESCRIPTION
## Summary
- explain how to install dependencies during DigitalOcean build

## Testing
- `make lint`
- `make test` *(fails: async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c62c391324832c9537fde8e31ca348