### PR TITLE
Fix static mount so API routes work

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,11 +13,6 @@ from .db import get_conn, init_db
 from .ingest import load_sample
 
 app = FastAPI()
-app.mount(
-    "/",
-    StaticFiles(directory=Path(__file__).with_name("static"), html=True),
-    name="static",
-)
 
 
 @app.on_event("startup")
@@ -113,3 +108,10 @@ def export_level(version_id: int, level: str):
         writer.writerow([r[c] for c in cols])
     buf.seek(0)
     return StreamingResponse(buf, media_type="text/csv")
+
+
+app.mount(
+    "/",
+    StaticFiles(directory=Path(__file__).with_name("static"), html=True),
+    name="static",
+)


### PR DESCRIPTION
## Summary
- ensure /api endpoints are not shadowed by static files by mounting static directory after API routes

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68c62d47057c832c980ea4c0be6e3bdc