### PR TITLE
ingest: add Excel loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ make dev
 
 Visit http://localhost:8000 to browse.
 
+## Load from Excel
+
+To ingest an official GICS Structure workbook:
+
+```bash
+python scripts/seed.py --excel path/to/gics.xlsx --label 2024-08 --effective 2024-08-01 [--source-url URL]
+```
+
+This creates a new `gics_version` and populates all hierarchy levels.
+
 ## Deployment
 
 App platforms like DigitalOcean expect both a build step and a start command.

--- a/backend/ingest.py
+++ b/backend/ingest.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import csv
+import logging
+import re
 from pathlib import Path
 from typing import Iterable
+
+import pandas as pd
 
 from .db import get_conn
 
@@ -53,4 +57,133 @@ def load_sample(
                     version_id,
                 ),
             )
+    return version_id
+
+
+_COL_PATTERNS = {
+    "sector_code": re.compile(r"sector.*code"),
+    "sector_name": re.compile(r"sector.*name"),
+    "group_code": re.compile(r"group.*code"),
+    "group_name": re.compile(r"group.*name"),
+    "industry_code": re.compile(r"industry.*code"),
+    "industry_name": re.compile(r"industry.*name"),
+    "sub_code": re.compile(r"sub.?industry.*code"),
+    "sub_name": re.compile(r"sub.?industry.*name"),
+    "definition": re.compile(r"definition"),
+}
+
+
+def _norm(col: str) -> str:
+    col = col.strip().lower()
+    col = re.sub(r"[-\s]+", "_", col)
+    return col
+
+
+def _clean(val: str | None) -> str | None:
+    if val is None:
+        return None
+    val = str(val).strip()
+    return val or None
+
+
+def _pad(val: str | None, length: int) -> str | None:
+    val = _clean(val)
+    if val is None:
+        return None
+    return val.zfill(length)
+
+
+def load_from_excel(
+    xlsx_path: str | Path,
+    label: str,
+    eff_date: str,
+    source_url: str | None = None,
+) -> int:
+    xlsx_path = Path(xlsx_path)
+    sheets = pd.read_excel(xlsx_path, sheet_name=None, dtype=str)
+    records: list[dict[str, str]] = []
+    for df in sheets.values():
+        df = df.rename(columns=lambda c: _norm(str(c)))
+        rename_map: dict[str, str] = {}
+        for col in list(df.columns):
+            n = col
+            for key, pat in _COL_PATTERNS.items():
+                if key not in rename_map and pat.search(n):
+                    rename_map[col] = key
+                    break
+        df = df.rename(columns=rename_map)
+        records.extend(df.to_dict(orient="records"))
+    with get_conn() as conn:
+        conn.execute("BEGIN")
+        cur = conn.execute(
+            "INSERT INTO gics_version(label, effective_date, source_url) VALUES (?,?,?)",
+            (label, eff_date, source_url),
+        )
+        version_id = cur.lastrowid
+        seen_sec: set[tuple[str, str]] = set()
+        seen_grp: set[tuple[str, str, str]] = set()
+        seen_ind: set[tuple[str, str, str]] = set()
+        seen_sub: set[tuple[str, str, str]] = set()
+        for r in records:
+            sec_code = _pad(r.get("sector_code"), 2)
+            sec_name = _clean(r.get("sector_name"))
+            if sec_code and sec_name and (sec_code, sec_name) not in seen_sec:
+                conn.execute(
+                    "INSERT OR IGNORE INTO gics_sector(code2, name, version_id) VALUES (?,?,?)",
+                    (sec_code, sec_name, version_id),
+                )
+                seen_sec.add((sec_code, sec_name))
+
+            grp_code = _pad(r.get("group_code"), 4)
+            grp_name = _clean(r.get("group_name"))
+            if grp_code and grp_name:
+                if not sec_code:
+                    sec_code = _pad(r.get("sector_code"), 2)
+                if not sec_code:
+                    logging.warning("Skipping group %s due to missing sector", grp_code)
+                else:
+                    key = (grp_code, grp_name, sec_code)
+                    if key not in seen_grp:
+                        conn.execute(
+                            "INSERT OR IGNORE INTO gics_group(code4, name, sector_code2, version_id) VALUES (?,?,?,?)",
+                            (grp_code, grp_name, sec_code, version_id),
+                        )
+                        seen_grp.add(key)
+
+            ind_code = _pad(r.get("industry_code"), 6)
+            ind_name = _clean(r.get("industry_name"))
+            if ind_code and ind_name:
+                if not grp_code:
+                    grp_code = _pad(r.get("group_code"), 4)
+                if not grp_code:
+                    logging.warning(
+                        "Skipping industry %s due to missing group", ind_code
+                    )
+                else:
+                    key = (ind_code, ind_name, grp_code)
+                    if key not in seen_ind:
+                        conn.execute(
+                            "INSERT OR IGNORE INTO gics_industry(code6, name, group_code4, version_id) VALUES (?,?,?,?)",
+                            (ind_code, ind_name, grp_code, version_id),
+                        )
+                        seen_ind.add(key)
+
+            sub_code = _pad(r.get("sub_code"), 8)
+            sub_name = _clean(r.get("sub_name"))
+            definition = _clean(r.get("definition"))
+            if sub_code and sub_name:
+                if not ind_code:
+                    ind_code = _pad(r.get("industry_code"), 6)
+                if not ind_code:
+                    logging.warning(
+                        "Skipping sub-industry %s due to missing industry", sub_code
+                    )
+                else:
+                    key = (sub_code, sub_name, ind_code)
+                    if key not in seen_sub:
+                        conn.execute(
+                            "INSERT OR IGNORE INTO gics_sub_industry(code8, name, definition, industry_code6, version_id) VALUES (?,?,?,?,?)",
+                            (sub_code, sub_name, definition, ind_code, version_id),
+                        )
+                        seen_sub.add(key)
     return version_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn[standard]
 pandas
+openpyxl
 python-multipart
 pytest
 httpx

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -4,17 +4,23 @@ import argparse
 from pathlib import Path
 
 from backend.db import init_db
-from backend.ingest import load_sample
+from backend.ingest import load_from_excel, load_sample
 
 
 def main() -> None:
     p = argparse.ArgumentParser()
-    p.add_argument("--csv", type=Path, required=True)
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--csv", type=Path)
+    g.add_argument("--excel", type=Path)
     p.add_argument("--label", required=True)
-    p.add_argument("--effective", required=False)
+    p.add_argument("--effective", required=True)
+    p.add_argument("--source-url")
     args = p.parse_args()
     init_db()
-    load_sample(args.csv, args.label, args.effective)
+    if args.csv:
+        load_sample(args.csv, args.label, args.effective)
+    else:
+        load_from_excel(args.excel, args.label, args.effective, args.source_url)
 
 
 if __name__ == "__main__":

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,13 +1,24 @@
+from __future__ import annotations
+
 from pathlib import Path
 
-from backend.db import init_db, get_conn, DB_PATH
-from backend.ingest import load_sample
+import asyncio
+
+import pandas as pd
+import pytest
+
+from backend.db import DB_PATH, get_conn, init_db
+from backend.ingest import load_from_excel, load_sample
 
 
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def fresh_db():
     if DB_PATH.exists():
         DB_PATH.unlink()
     init_db()
+    yield
+    if DB_PATH.exists():
+        DB_PATH.unlink()
 
 
 def test_load_sample_inserts_data():
@@ -16,3 +27,108 @@ def test_load_sample_inserts_data():
     with get_conn() as conn:
         cur = conn.execute("SELECT COUNT(*) FROM gics_sector WHERE version_id=1")
         assert cur.fetchone()[0] == 2
+
+
+def test_load_excel_happy_path(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "sector code": ["1", "1"],
+            "sector name": ["Energy", "Energy"],
+            "group-code": ["101", "101"],
+            "group name": ["Equip", "Equip"],
+            "industry code": ["10101", "10101"],
+            "industry name": ["Drilling", "Drilling"],
+            "subindustry code": ["1010101", "1010101"],
+            "subindustry name": ["Drill Sub", "Drill Sub"],
+        }
+    )
+
+    def fake_read_excel(*args, **kwargs):
+        return {"Sheet1": df}
+
+    monkeypatch.setattr(pd, "read_excel", fake_read_excel)
+
+    vid = load_from_excel("dummy.xlsx", "2024-08", "2024-08-01")
+    assert vid == 1
+    with get_conn() as conn:
+        cur = conn.execute(
+            "SELECT code2, name FROM gics_sector WHERE version_id=?", (vid,)
+        )
+        assert [tuple(r) for r in cur.fetchall()] == [("01", "Energy")]
+        cur = conn.execute(
+            "SELECT code4, name, sector_code2 FROM gics_group WHERE version_id=?",
+            (vid,),
+        )
+        assert [tuple(r) for r in cur.fetchall()] == [("0101", "Equip", "01")]
+        cur = conn.execute(
+            "SELECT code6, name, group_code4 FROM gics_industry WHERE version_id=?",
+            (vid,),
+        )
+        assert [tuple(r) for r in cur.fetchall()] == [("010101", "Drilling", "0101")]
+        cur = conn.execute(
+            "SELECT code8, name, industry_code6 FROM gics_sub_industry WHERE version_id=?",
+            (vid,),
+        )
+        assert [tuple(r) for r in cur.fetchall()] == [
+            ("01010101", "Drill Sub", "010101")
+        ]
+
+
+def test_missing_parent(monkeypatch, caplog):
+    df = pd.DataFrame(
+        {
+            "group code": ["202"],
+            "group name": ["No Sector"],
+        }
+    )
+
+    def fake_read_excel(*args, **kwargs):
+        return {"Sheet1": df}
+
+    monkeypatch.setattr(pd, "read_excel", fake_read_excel)
+
+    with caplog.at_level("WARNING"):
+        vid = load_from_excel("dummy.xlsx", "2024-09", "2024-09-01")
+    assert vid == 1
+    assert "missing sector" in caplog.text
+    with get_conn() as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM gics_group WHERE version_id=?", (vid,))
+        assert cur.fetchone()[0] == 0
+
+
+def test_api_reflects_excel(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "sectorcode": ["1"],
+            "sectorname": ["Energy"],
+            "groupcode": ["101"],
+            "groupname": ["Equip"],
+            "industrycode": ["10101"],
+            "industryname": ["Drilling"],
+            "subindustrycode": ["1010101"],
+            "subindustryname": ["Drill Sub"],
+        }
+    )
+
+    def fake_read_excel(*args, **kwargs):
+        return {"Sheet1": df}
+
+    monkeypatch.setattr(pd, "read_excel", fake_read_excel)
+    vid = load_from_excel("dummy.xlsx", "2024-10", "2024-10-01")
+
+    import httpx
+    from backend.main import app
+
+    async def inner() -> None:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            r = await client.get("/api/versions")
+            assert any(v["id"] == vid for v in r.json())
+            r = await client.get(f"/api/tree/{vid}")
+            tree = r.json()
+            assert tree[0]["code"] == "01"
+            assert tree[0]["groups"][0]["code"] == "0101"
+
+    asyncio.run(inner())

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,25 +1,36 @@
+import asyncio
+
 import httpx
 import pytest
 
-from backend.db import DB_PATH
+from backend.db import DB_PATH, init_db
+from backend.ingest import load_sample
 from backend.main import app
+from pathlib import Path
 
 
 @pytest.fixture(autouse=True, scope="module")
 def setup_db():
     if DB_PATH.exists():
         DB_PATH.unlink()
+    init_db()
+    load_sample(Path("backend/sample_gics.csv"), "sample", "2024-01-01")
     yield
     if DB_PATH.exists():
         DB_PATH.unlink()
 
 
-@pytest.mark.asyncio
-async def test_versions_and_tree():
-    async with httpx.AsyncClient(app=app, base_url="http://test") as client:
-        r = await client.get("/api/versions")
-        assert r.status_code == 200
-        vid = r.json()[0]["id"]
-        r = await client.get(f"/api/tree/{vid}")
-        assert r.status_code == 200
-        assert isinstance(r.json(), list)
+def test_versions_and_tree():
+    async def inner() -> None:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            r = await client.get("/api/versions")
+            assert r.status_code == 200
+            vid = r.json()[0]["id"]
+            r = await client.get(f"/api/tree/{vid}")
+            assert r.status_code == 200
+            assert isinstance(r.json(), list)
+
+    asyncio.run(inner())


### PR DESCRIPTION
## Summary
- load GICS hierarchy from Excel workbooks
- extend seed CLI with --excel flag
- document Excel ingestion and add tests

## Testing
- `python -m black backend/ingest.py scripts/seed.py tests/test_ingest.py tests/test_routes.py`
- `python -m ruff check backend scripts tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6325bc25c832cbd7429204fe4c444