### PR TITLE
api: ingest from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ make dev
 
 Visit http://localhost:8000 to browse.
 
+### Ingest via URL
+
+The web UI lets you add a new GICS version by URL. Enter the Excel file URL,
+label, and effective date then click **Ingest** to download and process it.
+
 ## Load from Excel
 
 To ingest an official GICS Structure workbook:

--- a/backend/static/app.js
+++ b/backend/static/app.js
@@ -8,6 +8,17 @@ async function fetchTree(id) {
   return res.json();
 }
 
+async function populateVersions(select) {
+  select.innerHTML = '';
+  const versions = await fetchVersions();
+  versions.forEach(v => {
+    const opt = document.createElement('option');
+    opt.value = v.id;
+    opt.textContent = `${v.label}`;
+    select.appendChild(opt);
+  });
+}
+
 function renderTree(node, container) {
   const ul = document.createElement('ul');
   for (const item of node) {
@@ -27,13 +38,7 @@ function renderTree(node, container) {
 
 async function init() {
   const versionSelect = document.getElementById('version');
-  const versions = await fetchVersions();
-  versions.forEach(v => {
-    const opt = document.createElement('option');
-    opt.value = v.id;
-    opt.textContent = `${v.label}`;
-    versionSelect.appendChild(opt);
-  });
+  await populateVersions(versionSelect);
   async function loadTree() {
     const tree = document.getElementById('tree');
     tree.innerHTML = '';
@@ -48,6 +53,18 @@ async function init() {
       const id = versionSelect.value;
       window.location = `/api/export/${id}/${level}`;
     });
+  });
+  document.getElementById('ingest-btn').addEventListener('click', async () => {
+    const url = document.getElementById('gics-url').value;
+    const label = document.getElementById('gics-label').value;
+    const eff = document.getElementById('gics-eff').value;
+    await fetch('/api/ingest-url', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: url, label: label, effective_date: eff })
+    });
+    await populateVersions(versionSelect);
+    await loadTree();
   });
 }
 

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -9,6 +9,12 @@
   <h1>GICS Explorer</h1>
   <label for="version">Version:</label>
   <select id="version"></select>
+  <div id="ingest">
+    <input id="gics-url" type="text" placeholder="GICS file URL">
+    <input id="gics-label" type="text" placeholder="Label">
+    <input id="gics-eff" type="date">
+    <button id="ingest-btn">Ingest</button>
+  </div>
   <div>
     <button data-level="sector">Export Sectors</button>
     <button data-level="group">Export Groups</button>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,6 @@
 import asyncio
-
 import httpx
+import pandas as pd
 import pytest
 
 from backend.db import DB_PATH, init_db
@@ -32,5 +32,48 @@ def test_versions_and_tree():
             r = await client.get(f"/api/tree/{vid}")
             assert r.status_code == 200
             assert isinstance(r.json(), list)
+
+    asyncio.run(inner())
+
+
+def test_ingest_url(monkeypatch, tmp_path):
+    df = pd.DataFrame(
+        {
+            "Sector Code": ["10"],
+            "Sector Name": ["Energy"],
+            "Group Code": ["1010"],
+            "Group Name": ["Energy Equipment"],
+            "Industry Code": ["101010"],
+            "Industry Name": ["Oil & Gas Drilling"],
+            "Sub Code": ["10101010"],
+            "Sub Name": ["Drilling"],
+        }
+    )
+    xlsx = tmp_path / "gics.xlsx"
+    df.to_excel(xlsx, index=False)
+
+    def fake_get(self, url, *args, **kwargs):
+        return httpx.Response(
+            200, content=xlsx.read_bytes(), request=httpx.Request("GET", url)
+        )
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+
+    async def inner() -> None:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            payload = {
+                "url": "http://example.com/gics.xlsx",
+                "label": "u1",
+                "effective_date": "2024-09-01",
+            }
+            r = await client.post("/api/ingest-url", json=payload)
+            assert r.status_code == 200
+            vid = r.json()["version_id"]
+            r = await client.get("/api/versions")
+            ids = [v["id"] for v in r.json()]
+            assert vid in ids
 
     asyncio.run(inner())


### PR DESCRIPTION
## Summary
- allow ingesting GICS Excel files via `/api/ingest-url`
- add frontend controls to submit URL, label and effective date
- document URL ingest and test end-to-end

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c74b88c2ac832cb19f2a5d31e0de65