### PR TITLE
ui: fix ingest form submit

### DIFF
--- a/backend/static/app.js
+++ b/backend/static/app.js
@@ -54,7 +54,8 @@ async function init() {
       window.location = `/api/export/${id}/${level}`;
     });
   });
-  document.getElementById('ingest-btn').addEventListener('click', async () => {
+  document.getElementById('ingest-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
     const url = document.getElementById('gics-url').value;
     const label = document.getElementById('gics-label').value;
     const eff = document.getElementById('gics-eff').value;

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -9,12 +9,12 @@
   <h1>GICS Explorer</h1>
   <label for="version">Version:</label>
   <select id="version"></select>
-  <div id="ingest">
+  <form id="ingest-form">
     <input id="gics-url" type="text" placeholder="GICS file URL">
     <input id="gics-label" type="text" placeholder="Label">
     <input id="gics-eff" type="date">
-    <button id="ingest-btn">Ingest</button>
-  </div>
+    <button id="ingest-btn" type="submit">Ingest</button>
+  </form>
   <div>
     <button data-level="sector">Export Sectors</button>
     <button data-level="group">Export Groups</button>


### PR DESCRIPTION
## Summary
- handle ingest form submission via `submit` event and prevent default
- wrap ingest inputs in a form with a submit button so requests fire

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c76017715c832c8474d69e67a8f682