### PR TITLE
ui: default ingest URL

### DIFF
--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -10,7 +10,7 @@
   <label for="version">Version:</label>
   <select id="version"></select>
   <form id="ingest-form">
-    <input id="gics-url" type="text" placeholder="GICS file URL">
+    <input id="gics-url" type="text" placeholder="GICS file URL" value="https://www.msci.com/documents/1296102/29559863/GICS_structure_and_definitions_effective_close_of_March_17_2023.xlsx/e47b8086-56fd-c9d2-196f-c2054b24b1d4?t=1670964718735&utm_source=chatgpt.com">
     <input id="gics-label" type="text" placeholder="Label">
     <input id="gics-eff" type="date">
     <button type="submit">Ingest</button>


### PR DESCRIPTION
## Summary
- default the ingest form to the latest GICS definitions spreadsheet

## Testing
- `make install` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fafc220c832c8ab55a8e54ab5cf9