### PR TITLE
Fix sub-industry tree output

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -116,7 +116,14 @@ def get_tree(version_id: int) -> list[dict[str, Any]]:
                         {
                             "code": ind["code6"],
                             "name": ind["name"],
-                            "subs": [dict(s) for s in subs],
+                            "subs": [
+                                {
+                                    "code": s["code8"],
+                                    "name": s["name"],
+                                    "definition": s["definition"],
+                                }
+                                for s in subs
+                            ],
                         }
                     )
                 group_list.append(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -31,7 +31,14 @@ def test_versions_and_tree():
             vid = r.json()[0]["id"]
             r = await client.get(f"/api/tree/{vid}")
             assert r.status_code == 200
-            assert isinstance(r.json(), list)
+            tree = r.json()
+            assert isinstance(tree, list)
+            first_sub = (
+                tree[0]["groups"][0]["industries"][0]["subs"][0]
+            )
+            assert first_sub["code"].isdigit()
+            assert first_sub["name"]
+            assert "definition" in first_sub
 
     asyncio.run(inner())
 


### PR DESCRIPTION
## Summary
- normalize sub-industry entries in the tree response to include the shared `code` field
- add a regression test to ensure sub-industries expose code, name, and definition values

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c8ca83598c832cbc48e7b60c822703