### PR TITLE
Bootstrap default ingest from official workbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Minimal GICS browser built with FastAPI, SQLite and vanilla JavaScript.
 ```bash
 make venv
 make install
-make seed
 make dev
 ```
 
-Visit http://localhost:8000 to browse.
+On first launch the app downloads and ingests the official GICS structure from
+`https://www.msci.com/documents/1296102/29559863/GICS_structure_and_definitions_effective_close_of_March_17_2023.xlsx`.
+Visit http://localhost:8000 to browse. Use `make seed` if you want to load the
+small sample CSV instead.
 
 ### Ingest via URL
 

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -10,7 +10,7 @@
   <label for="version">Version:</label>
   <select id="version"></select>
   <form id="ingest-form">
-    <input id="gics-url" type="text" placeholder="GICS file URL" value="https://www.msci.com/documents/1296102/29559863/GICS_structure_and_definitions_effective_close_of_March_17_2023.xlsx/e47b8086-56fd-c9d2-196f-c2054b24b1d4?t=1670964718735&utm_source=chatgpt.com">
+    <input id="gics-url" type="text" placeholder="GICS file URL" value="https://www.msci.com/documents/1296102/29559863/GICS_structure_and_definitions_effective_close_of_March_17_2023.xlsx">
     <input id="gics-label" type="text" placeholder="Label">
     <input id="gics-eff" type="date">
     <button type="submit">Ingest</button>


### PR DESCRIPTION
## Summary
- replace the CSV auto-seed with a helper that downloads and ingests the official MSCI workbook on startup when the database is empty
- reuse the helper for the ingest-by-URL endpoint and document the new bootstrap behaviour
- update the ingest form default URL to point at the official workbook link

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c8ce6ec2e4832cad3390f2d1dd4c38