### PR TITLE
Persist SQLite database under /var/lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ On first launch the app downloads and ingests the official GICS structure from
 Visit http://localhost:8000 to browse. Use `make seed` if you want to load the
 small sample CSV instead.
 
+## Database storage
+
+The app stores its SQLite database at `/var/lib/gics-explorer/gics.db` so data
+survives application restarts and new deployments. Set the
+`GICS_DB_PATH` environment variable if you need to place the database elsewhere
+(for example when running locally without permission to create `/var/lib`
+directories).
+
 ### Ingest via URL
 
 The web UI lets you add a new GICS version by URL. Enter the Excel file URL,

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,13 +1,30 @@
 from __future__ import annotations
 
+import logging
+import os
 import sqlite3
 from pathlib import Path
 from sqlite3 import Connection, Row
 
-DB_PATH = Path("gics.db")
+logger = logging.getLogger(__name__)
+
+DEFAULT_DB_PATH = Path("/var/lib/gics-explorer/gics.db")
+DB_PATH = Path(os.environ.get("GICS_DB_PATH", DEFAULT_DB_PATH)).expanduser()
+
+
+def _ensure_parent_directory(path: Path) -> None:
+    parent = path.parent
+    if parent and parent != Path("."):
+        try:
+            parent.mkdir(parents=True, exist_ok=True)
+        except PermissionError as exc:
+            raise RuntimeError(
+                f"Unable to create database directory {parent!s}."
+            ) from exc
 
 
 def get_conn() -> Connection:
+    _ensure_parent_directory(DB_PATH)
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = Row
     conn.execute("PRAGMA foreign_keys = ON")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+TEST_DB_DIR = Path(__file__).resolve().parent / "_tmp"
+TEST_DB_DIR.mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("GICS_DB_PATH", str(TEST_DB_DIR / "gics.db"))


### PR DESCRIPTION
## Summary
- default the SQLite database location to /var/lib/gics-explorer/gics.db and ensure the directory is created before use
- allow overriding the database location with the GICS_DB_PATH environment variable for local setups
- document the new storage location and set up tests to use a temporary database path

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c8d16c437c832c9d30e1fe1c87168b